### PR TITLE
Add Flutter skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Flutter build outputs
+build/
+.dart_tool/
+.flutter-plugins
+.flutter-plugins-dependencies
+.packages
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# nobita
+# nobita Flutter App
+
+This repository contains a minimal Flutter application skeleton.
+
+## Getting Started
+
+1. Ensure you have Flutter installed.
+2. Run `flutter pub get` to install dependencies.
+3. Use `flutter run` to launch the app on an emulator or device.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+void main() => runApp(const MyApp());
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Flutter Demo',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Flutter App')),
+      body: const Center(child: Text('Hello, world!')),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,13 @@
+name: nobita_flutter_app
+version: 0.1.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+dependencies:
+  flutter:
+    sdk: flutter
+  cupertino_icons: ^1.0.2
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- initialize Flutter project structure
- add a simple `main.dart`
- configure `pubspec.yaml`
- document basic usage in README
- add `.gitignore` for Flutter artifacts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684e8e38a94c832f89e7fcaa02fe2d9b